### PR TITLE
Update 11-01-vnet-buildout.ps1

### DIFF
--- a/11-Design-and-Implement-an-Azure-Virtual-WAN-Architecture/11-01-vnet-buildout.ps1
+++ b/11-Design-and-Implement-an-Azure-Virtual-WAN-Architecture/11-01-vnet-buildout.ps1
@@ -38,9 +38,9 @@ az network vnet create --name spoke-2-vnet --resource-group $rg --location $loca
 
 # Create two Linux machines. One in each network
 
-az vm create --resource-group $rg --name spoke-1-vm --image UbuntuLTS --generate-ssh-keys --public-ip-address myPublicIP-nva --public-ip-sku Standard --vnet-name spoke-1-vnet --subnet spoke-1-subnet-a --size Standard_B1s
+az vm create --resource-group $rg --name spoke-1-vm --image Ubuntu2204 --generate-ssh-keys --public-ip-address myPublicIP-nva --public-ip-sku Standard --vnet-name spoke-1-vnet --subnet spoke-1-subnet-a --size Standard_B1s
 
-az vm create --resource-group $rg --name spoke-2-vm --image UbuntuLTS --generate-ssh-keys --public-ip-address myPublicIP-spoke-2-vm --public-ip-sku Standard --vnet-name spoke-2-vnet --subnet spoke-2-subnet-a --size Standard_B1s
+az vm create --resource-group $rg --name spoke-2-vm --image Ubuntu2204 --generate-ssh-keys --public-ip-address myPublicIP-spoke-2-vm --public-ip-sku Standard --vnet-name spoke-2-vnet --subnet spoke-2-subnet-a --size Standard_B1s
 
 
 # Add rules to default NIC NSGs to allow ICMP


### PR DESCRIPTION
Updated UbuntuLTS to be Ubuntu2204.
to resolve the error:
---
Invalid image "UbuntuLTS". Use a valid image URN, custom image name, custom image id, VHD blob URI, or pick an image from ['CentOS85Gen2', 'Debian11', 'FlatcarLinuxFreeGen2', 'OpenSuseLeap154Gen2', 'RHELRaw8LVMGen2', 'SuseSles15SP3', 'Ubuntu2204', 'Win2022Datacenter', 'Win2022AzureEditionCore', 'Win2019Datacenter', 'Win2016Datacenter', 'Win2012R2Datacenter', 'Win2012Datacenter', 'Win2008R2SP1']. See vm create -h for more information on specifying an image.